### PR TITLE
Updated the deletion of the schematics.

### DIFF
--- a/WorldEdit/WorldEdit.cs
+++ b/WorldEdit/WorldEdit.cs
@@ -20,6 +20,7 @@ using TShockAPI.DB;
 using WorldEdit.Commands;
 using WorldEdit.Expressions;
 using WorldEdit.Extensions;
+using Microsoft.VisualBasic.FileIO;
 
 namespace WorldEdit
 {
@@ -2097,7 +2098,7 @@ namespace WorldEdit
 							return;
 						}
 
-						File.Delete(path);
+						FileSystem.DeleteFile(path, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
 						e.Player.SendErrorMessage("Deleted schematic '{0}'.", e.Parameters[2]);
 					}
 					return;


### PR DESCRIPTION
All schematics deleted by users now go to the recycle garbage can. They can either be restored again, allowing the server owner to decide whether schematic is needed or not, or deleted irretrievably. 
In this way, two stages of deletion are added.