### PR TITLE
Update dependency versions

### DIFF
--- a/WorldEdit/WorldEdit.csproj
+++ b/WorldEdit/WorldEdit.csproj
@@ -5,10 +5,10 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
     <PackageReference Include="OTAPI.Upcoming" Version="3.3.10" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="MySql.Data" Version="9.3.0" />
+    <PackageReference Include="MySql.Data" Version="9.1.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="TSAPI" Version="6.0.0" />


### PR DESCRIPTION
With the Microsoft.Data.Sqlite and MySql.Data dependencies, there were issues on plugin load with the version being different than what TShock uses.